### PR TITLE
Added phalcon4 official against php74 and reoganized psr extension naming

### DIFF
--- a/Abstract/abstract-php-extension.rb
+++ b/Abstract/abstract-php-extension.rb
@@ -33,7 +33,17 @@ class AbstractPhpExtension < Formula
       i = IO.popen("#{phpize} -v")
       out = i.readlines.join("")
       i.close
-      { 53 => 20090626, 54 => 20100412, 55 => 20121113, 56 => 20131106, 70 => 20151012, 71 => 20160303, 72 => 20170718 }.each do |v, api|
+      {
+        53 => 20090626,
+        54 => 20100412,
+        55 => 20121113,
+        56 => 20131106,
+        70 => 20151012,
+        71 => 20160303,
+        72 => 20170718,
+        73 => 20180731,
+        74 => 20190902
+      }.each do |v, api|
         installed_php_version = v.to_s if out.match(/#{api}/)
       end
 
@@ -257,5 +267,14 @@ class AbstractPhp73Extension < AbstractPhpExtension
   def self.init(opts = [])
     super()
     depends_on "php@7.3" => opts if build.with?("homebrew-php")
+  end
+end
+
+class AbstractPhp74Extension < AbstractPhpExtension
+  include AbstractPhpVersion::Php74Defs
+
+  def self.init(opts = [])
+    super()
+    depends_on "php@7.4" => opts if build.with?("homebrew-php")
   end
 end

--- a/Abstract/abstract-php-version.rb
+++ b/Abstract/abstract-php-version.rb
@@ -87,11 +87,23 @@ class AbstractPhpVersion < Formula
   end
 
   module Php73Defs
-    PHP_SRC_TARBALL = "https://php.net/get/php-7.3.11.tar.bz2/from/this/mirror".freeze
+    PHP_SRC_TARBALL = "https://php.net/get/php-7.3.13.tar.bz2/from/this/mirror".freeze
     PHP_GITHUB_URL  = "https://github.com/php/php-src.git".freeze
-    PHP_VERSION     = "7.3.11".freeze
-    PHP_BRANCH      = "PHP-7.3.11".freeze
+    PHP_VERSION     = "7.3.13".freeze
+    PHP_BRANCH      = "PHP-7.3.13".freeze
     PHP_FORMULA     = "php@7.3".freeze
+
+    PHP_CHECKSUM    = {
+      :sha256 => "92d1ff4b13c7093635f1ec338a5e6891ca99b10e65fbcadd527e5bb84d11b5e7",
+    }.freeze
+  end
+
+  module Php74Defs
+    PHP_SRC_TARBALL = "https://php.net/get/php-7.4.1.tar.bz2/from/this/mirror".freeze
+    PHP_GITHUB_URL  = "https://github.com/php/php-src.git".freeze
+    PHP_VERSION     = "7.4.1".freeze
+    PHP_BRANCH      = "PHP-7.4.1".freeze
+    PHP_FORMULA     = "php@7.4".freeze
 
     PHP_CHECKSUM    = {
       :sha256 => "92d1ff4b13c7093635f1ec338a5e6891ca99b10e65fbcadd527e5bb84d11b5e7",

--- a/Aliases/phalcon
+++ b/Aliases/phalcon
@@ -1,1 +1,1 @@
-../Formula/phalcon@3.4.rb
+../Formula/phalcon@4.0.0.rb

--- a/Aliases/phalcon73
+++ b/Aliases/phalcon73
@@ -1,0 +1,1 @@
+../Formula/phalcon@73_4.0.0.rb

--- a/Aliases/phalcon@4
+++ b/Aliases/phalcon@4
@@ -1,0 +1,1 @@
+../Formula/phalcon@4.0.0.rb

--- a/Aliases/phalcon@4
+++ b/Aliases/phalcon@4
@@ -1,1 +1,0 @@
-../Formula/phalcon@4.0rc3.rb

--- a/Aliases/psr
+++ b/Aliases/psr
@@ -1,0 +1,1 @@
+../Formula/psr@74.rb

--- a/Formula/phalcon@4.0.0.rb
+++ b/Formula/phalcon@4.0.0.rb
@@ -10,7 +10,7 @@ class PhalconAT400 < AbstractPhp74Extension
 
   bottle do
     cellar :any_skip_relocation
-    root_url "https://github.com/phalcon/homebrew-tap/releases/download/v4_rc"
+    root_url "https://github.com/phalcon/homebrew-tap/releases/download/v4.0.x"
     sha256 "7c7eb1ec5fa66a15c168fba4eec1bf7f0f2d05acf0e850b6156f53b0c8974ddb" => :high_sierra
     sha256 "ef46d66685ba718574c1ade55de2e8efac32c5291d6c4bdb8b6d31d42e1cee69" => :sierra
   end

--- a/Formula/phalcon@4.0.0.rb
+++ b/Formula/phalcon@4.0.0.rb
@@ -1,0 +1,32 @@
+require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
+
+class PhalconAT400 < AbstractPhp74Extension
+  init
+  desc "Full-stack PHP framework"
+  homepage "https://phalconphp.com/"
+  url "https://github.com/phalcon/cphalcon/archive/4.0.x.tar.gz"
+  sha256 "b8c8c5c331fed6c216ed5f799aadd3c06dac66e9b814a48c38ec9df4eb4c642c"
+  head "https://github.com/phalcon/cphalcon.git"
+
+  bottle do
+    cellar :any_skip_relocation
+    root_url "https://github.com/phalcon/homebrew-tap/releases/download/v4_rc"
+    sha256 "7c7eb1ec5fa66a15c168fba4eec1bf7f0f2d05acf0e850b6156f53b0c8974ddb" => :high_sierra
+    sha256 "ef46d66685ba718574c1ade55de2e8efac32c5291d6c4bdb8b6d31d42e1cee69" => :sierra
+  end
+
+  depends_on "pcre"
+  depends_on "psr"
+
+  def install
+    Dir.chdir "build/php7/64bits"
+
+    safe_phpize
+
+    system "./configure", "--prefix=#{prefix}", phpconfig, "--enable-phalcon"
+    system "make"
+
+    prefix.install "modules/phalcon.so"
+    write_config_file if build.with? "config-file"
+  end
+end

--- a/Formula/phalcon@73_4.0.0.rb
+++ b/Formula/phalcon@73_4.0.0.rb
@@ -1,0 +1,29 @@
+require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
+
+class PhalconAT73400 < AbstractPhp73Extension
+  init
+  desc "Full-stack PHP framework"
+  homepage "https://phalconphp.com/"
+  url "https://github.com/phalcon/cphalcon/archive/v4.0.0.tar.gz"
+  sha256 "9d3fbaac4235110e000b8020543d53342aa7d274926dc44207753bc201121d7b"
+  head "https://github.com/phalcon/cphalcon.git"
+
+  bottle do
+    cellar :any_skip_relocation
+  end
+
+  depends_on "pcre"
+  depends_on "psr@73"
+
+  def install
+    Dir.chdir "build/php7/64bits"
+
+    safe_phpize
+
+    system "./configure", "--prefix=#{prefix}", phpconfig, "--enable-phalcon"
+    system "make"
+
+    prefix.install "modules/phalcon.so"
+    write_config_file if build.with? "config-file"
+  end
+end

--- a/Formula/psr@73.rb
+++ b/Formula/psr@73.rb
@@ -1,0 +1,28 @@
+require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
+
+class PsrAT73 < AbstractPhp73Extension
+  init
+  desc "PHP extension providing the accepted PSR interfaces "
+  homepage "https://phalconphp.com/"
+  url "https://github.com/jbboehr/php-psr/archive/v0.7.0.tar.gz"
+  sha256 "648aac07414f8c6e5c80728cf91fa8174bbd18dd41ae1a90168b510a507cf805"
+  head "https://github.com/jbboehr/php-psr.git"
+
+  bottle do
+    cellar :any_skip_relocation
+  end
+
+  depends_on "pcre"
+
+  def install
+    safe_phpize
+
+    system "./configure", "--prefix=#{prefix}", phpconfig, "--enable-psr"
+    system "make"
+    
+    prefix.install "modules/psr.so"
+    prefix.install "modules/psr.la"
+
+    write_config_file if build.with? "config-file"
+  end
+end

--- a/Formula/psr@74.rb
+++ b/Formula/psr@74.rb
@@ -10,7 +10,7 @@ class PsrAT74 < AbstractPhp74Extension
 
   bottle do
     cellar :any_skip_relocation
-    root_url "https://github.com/phalcon/homebrew-tap/releases/download/v4_rc"
+    root_url "https://github.com/phalcon/homebrew-tap/releases/download/v4.0.x"
     sha256 "06249d93567e517f25dabf0e92e0b9b2c04562d2ad1c28b734973d76e94508cb" => :sierra
   end
 

--- a/Formula/psr@74.rb
+++ b/Formula/psr@74.rb
@@ -1,6 +1,6 @@
 require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 
-class Psr < AbstractPhp73Extension
+class PsrAT74 < AbstractPhp74Extension
   init
   desc "PHP extension providing the accepted PSR interfaces "
   homepage "https://phalconphp.com/"
@@ -10,6 +10,8 @@ class Psr < AbstractPhp73Extension
 
   bottle do
     cellar :any_skip_relocation
+    root_url "https://github.com/phalcon/homebrew-tap/releases/download/v4_rc"
+    sha256 "06249d93567e517f25dabf0e92e0b9b2c04562d2ad1c28b734973d76e94508cb" => :sierra
   end
 
   depends_on "pcre"


### PR DESCRIPTION
### Details
Technically this does not build against the `4.0.0` tag https://github.com/phalcon/cphalcon/releases/tag/v4.0.0 as there is an issue building the 64bit version. As there are some included fixes in `4.0.x` related to https://github.com/phalcon/cphalcon/issues/14577 I have built and bottled against this tag for now.

The nuance is that formula can have an @ 'AT' version defined to allow for some sort of mechanism
to have multiple versions of the same formula. Unfortunately AT is generally used for the version of the lib.

In the case of psr i am just versioning against php version.

I would like to eventually fork this tap by php version.
That way each formula can be created a single time and the end user can specify
which tap they want to employ assuring that updates always apply to the same php version

### Other Resources
https://github.com/phalcon/homebrew-tap/releases/tag/v4.0.x
Represents a location for bottle binaries for high_sierra and sierra related to `psr` and `phalcon@4.0.0` releases