### PR TITLE
Pks/provide a fixed sha against devel for bottle building in 4 0 0

### DIFF
--- a/Formula/phalcon@4.0.0.rb
+++ b/Formula/phalcon@4.0.0.rb
@@ -12,7 +12,7 @@ class PhalconAT400 < AbstractPhp74Extension
     cellar :any_skip_relocation
     root_url "https://github.com/phalcon/homebrew-tap/releases/download/v4.0.x"
     sha256 "e645dfbf9cb485380f7cd92740dc5dcd30f8b6f4b9051ee3f8ec11f903e9243a" => :mojave
-    sha256 "7c7eb1ec5fa66a15c168fba4eec1bf7f0f2d05acf0e850b6156f53b0c8974ddb" => :high_sierra
+    sha256 "2b827bbdd2b52f136af1cfa1e209457f0264c5d9a0804345982e0a57d50aa940" => :high_sierra
     sha256 "8f04465129e223fa9e261a73ce3a9d7cdecf6786890c854bd38b560852ed6ec6" => :sierra
   end
 

--- a/Formula/phalcon@4.0.0.rb
+++ b/Formula/phalcon@4.0.0.rb
@@ -11,6 +11,7 @@ class PhalconAT400 < AbstractPhp74Extension
   bottle do
     cellar :any_skip_relocation
     root_url "https://github.com/phalcon/homebrew-tap/releases/download/v4.0.x"
+    sha256 "e645dfbf9cb485380f7cd92740dc5dcd30f8b6f4b9051ee3f8ec11f903e9243a" => :mojave
     sha256 "7c7eb1ec5fa66a15c168fba4eec1bf7f0f2d05acf0e850b6156f53b0c8974ddb" => :high_sierra
     sha256 "ef46d66685ba718574c1ade55de2e8efac32c5291d6c4bdb8b6d31d42e1cee69" => :sierra
   end

--- a/Formula/phalcon@4.0.0.rb
+++ b/Formula/phalcon@4.0.0.rb
@@ -13,7 +13,7 @@ class PhalconAT400 < AbstractPhp74Extension
     root_url "https://github.com/phalcon/homebrew-tap/releases/download/v4.0.x"
     sha256 "e645dfbf9cb485380f7cd92740dc5dcd30f8b6f4b9051ee3f8ec11f903e9243a" => :mojave
     sha256 "7c7eb1ec5fa66a15c168fba4eec1bf7f0f2d05acf0e850b6156f53b0c8974ddb" => :high_sierra
-    sha256 "ef46d66685ba718574c1ade55de2e8efac32c5291d6c4bdb8b6d31d42e1cee69" => :sierra
+    sha256 "8f04465129e223fa9e261a73ce3a9d7cdecf6786890c854bd38b560852ed6ec6" => :sierra
   end
 
   depends_on "pcre"

--- a/Formula/phalcon@4.0.0.rb
+++ b/Formula/phalcon@4.0.0.rb
@@ -4,8 +4,8 @@ class PhalconAT400 < AbstractPhp74Extension
   init
   desc "Full-stack PHP framework"
   homepage "https://phalconphp.com/"
-  url "https://github.com/phalcon/cphalcon/archive/4.0.x.tar.gz"
-  sha256 "b8c8c5c331fed6c216ed5f799aadd3c06dac66e9b814a48c38ec9df4eb4c642c"
+  url "https://github.com/phalcon/cphalcon/archive/4.0.0_homebrew.tar.gz"
+  sha256 "aacdb5eff46937e803fda72a466e96864b0bf9ce3df286e04b6519aecac37503"
   head "https://github.com/phalcon/cphalcon.git"
 
   bottle do


### PR DESCRIPTION
There was a bug blocking head builds in 4.0.0 release so I created a branch that is based off 4.0.x but will be unchanged while we prepare the next release which includes the compilation fixes. This gives some stability to the homebrew build 4.0.0 so we can create bottles which for the most part eliminates this issue in the future