### PR TITLE
Fix #25 - psr hash mismatch for php 7.4 

### DIFF
--- a/Formula/psr@74.rb
+++ b/Formula/psr@74.rb
@@ -4,7 +4,7 @@ class PsrAT74 < AbstractPhp74Extension
   init
   desc "PHP extension providing the accepted PSR interfaces "
   homepage "https://phalconphp.com/"
-  url "https://github.com/jbboehr/php-psr/archive/v0.7.0.tar.gz"
+  url "https://github.com/jbboehr/php-psr/archive/v1.0.0.tar.gz"
   sha256 "f85be1d1434368abd16e06b81e394487f81b5e2706220f01c85558ba486ee3e7"
   head "https://github.com/jbboehr/php-psr.git"
 


### PR DESCRIPTION
There's a hash mismatch for psr on php 7.4.

The sha256 of php-psr-1.0.0.tar.gz is:
f85be1d1434368abd16e06b81e394487f81b5e2706220f01c85558ba486ee3e7
The sha256 of php-psr-0.7.0.tar.gz is:
648aac07414f8c6e5c80728cf91fa8174bbd18dd41ae1a90168b510a507cf805

The hash on master is currently the hash for 1.0.0, but it's linking to the URL for 0.7.0. This needs to be updated to psr 1.0.0

https://github.com/phalcon/homebrew-tap/issues/25