### PR TITLE
Changed formula for psr@74, tried to fix #27

### DIFF
--- a/Formula/psr@74.rb
+++ b/Formula/psr@74.rb
@@ -4,7 +4,7 @@ class PsrAT74 < AbstractPhp74Extension
   init
   desc "PHP extension providing the accepted PSR interfaces "
   homepage "https://phalconphp.com/"
-  url "https://github.com/jbboehr/php-psr/archive/v1.0.0.tar.gz"
+  url "https://github.com/jbboehr/php-psr/archive/v0.7.0.tar.gz"
   sha256 "f85be1d1434368abd16e06b81e394487f81b5e2706220f01c85558ba486ee3e7"
   head "https://github.com/jbboehr/php-psr.git"
 


### PR DESCRIPTION
`brew install phalcon` was failing here #27 so I fixed the formula in psr@74.rb.

I didn't changed the sha256 hash, but it worked for me anyway.